### PR TITLE
Fix/split otp deep nested detection

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -186,7 +186,7 @@ const handleMessage = async (
             // Load and set custom mappings before matching
             const customMappings = await customMappingsStorage.getMappings();
             setCustomMappings(customMappings);
-            const matches = matchCodesToDomain(codes, message.domain);
+            const matches = matchCodesToDomain(codes, message.domain, message.path);
             const timeOffset = await getTimeOffset();
             return { success: true, data: { matches, timeOffset, authState } };
         }

--- a/src/background/storage.ts
+++ b/src/background/storage.ts
@@ -233,14 +233,62 @@ export const settingsStorage = {
 };
 
 /**
- * Custom domain mappings storage.
+ * Sync storage operations (synced across devices via browser account).
+ * Falls back to local storage if sync storage is not available.
+ */
+export const syncStore = {
+    async get<T>(key: string): Promise<T | undefined> {
+        if (browser.storage.sync) {
+            const result = await browser.storage.sync.get(key);
+            return result[key] as T | undefined;
+        }
+        // Fallback to local storage
+        return localStore.get<T>(key);
+    },
+
+    async set(key: string, value: unknown): Promise<void> {
+        if (browser.storage.sync) {
+            await browser.storage.sync.set({ [key]: value });
+        } else {
+            await localStore.set(key, value);
+        }
+    },
+
+    async remove(key: string): Promise<void> {
+        if (browser.storage.sync) {
+            await browser.storage.sync.remove(key);
+        } else {
+            await localStore.remove(key);
+        }
+    },
+};
+
+/**
+ * Custom domain mappings storage (synced across devices).
  */
 export const customMappingsStorage = {
     async getMappings(): Promise<CustomDomainMapping[]> {
-        const mappings = await localStore.get<CustomDomainMapping[]>(
+        // Try sync storage first
+        const syncMappings = await syncStore.get<CustomDomainMapping[]>(
             KEYS.CUSTOM_DOMAIN_MAPPINGS
         );
-        return mappings ?? [];
+        if (syncMappings && syncMappings.length > 0) {
+            return syncMappings;
+        }
+
+        // Migrate from local storage if exists (one-time migration)
+        const localMappings = await localStore.get<CustomDomainMapping[]>(
+            KEYS.CUSTOM_DOMAIN_MAPPINGS
+        );
+        if (localMappings && localMappings.length > 0) {
+            // Migrate to sync storage
+            await syncStore.set(KEYS.CUSTOM_DOMAIN_MAPPINGS, localMappings);
+            // Clean up local storage
+            await localStore.remove(KEYS.CUSTOM_DOMAIN_MAPPINGS);
+            return localMappings;
+        }
+
+        return [];
     },
 
     async addMapping(mapping: Omit<CustomDomainMapping, "createdAt">): Promise<void> {
@@ -255,7 +303,7 @@ export const customMappingsStorage = {
             createdAt: Date.now(),
         };
         filtered.push(newMapping);
-        await localStore.set(KEYS.CUSTOM_DOMAIN_MAPPINGS, filtered);
+        await syncStore.set(KEYS.CUSTOM_DOMAIN_MAPPINGS, filtered);
     },
 
     async deleteMapping(domain: string): Promise<void> {
@@ -263,10 +311,11 @@ export const customMappingsStorage = {
         const filtered = mappings.filter(
             (m) => m.domain.toLowerCase() !== domain.toLowerCase()
         );
-        await localStore.set(KEYS.CUSTOM_DOMAIN_MAPPINGS, filtered);
+        await syncStore.set(KEYS.CUSTOM_DOMAIN_MAPPINGS, filtered);
     },
 
     async clearMappings(): Promise<void> {
+        await syncStore.remove(KEYS.CUSTOM_DOMAIN_MAPPINGS);
         await localStore.remove(KEYS.CUSTOM_DOMAIN_MAPPINGS);
     },
 };

--- a/src/content/detector.ts
+++ b/src/content/detector.ts
@@ -556,54 +556,115 @@ const findLabelForInput = (input: HTMLInputElement): HTMLLabelElement | null => 
 };
 
 /**
+ * Find the lowest common ancestor of two DOM elements within a reasonable depth.
+ */
+const findCommonAncestor = (a: HTMLElement, b: HTMLElement, maxDepth = 6): HTMLElement | null => {
+    const ancestors = new Set<HTMLElement>();
+    let node: HTMLElement | null = a;
+    for (let i = 0; i < maxDepth && node; i++) {
+        ancestors.add(node);
+        node = node.parentElement;
+    }
+    node = b;
+    for (let i = 0; i < maxDepth && node; i++) {
+        if (ancestors.has(node)) return node;
+        node = node.parentElement;
+    }
+    return null;
+};
+
+/**
+ * Check if two inputs are visually adjacent (on the same horizontal row and
+ * close together). This handles deeply nested DOM structures where structural
+ * checks (sibling/parent) fail.
+ */
+const areVisuallyAdjacent = (a: HTMLInputElement, b: HTMLInputElement): boolean => {
+    const rectA = a.getBoundingClientRect();
+    const rectB = b.getBoundingClientRect();
+
+    // Must be on roughly the same vertical line (within 20px tolerance)
+    if (Math.abs(rectA.top - rectB.top) > 20) return false;
+
+    // Horizontal gap should be reasonable (less than 80px apart)
+    const gap = rectB.left - (rectA.left + rectA.width);
+    if (gap < -5 || gap > 80) return false;
+
+    return true;
+};
+
+/**
  * Detect split OTP inputs (6 adjacent single-character inputs).
+ * Uses a combination of DOM structure and visual position to handle
+ * deeply-nested wrappers common in modern frameworks.
  */
 const detectSplitInputs = (): MFAFieldDetection | null => {
+    // Broader selector: also match inputs without maxlength that are very
+    // narrow (styled to accept a single character), or inputs with size="1"
     const allInputs = document.querySelectorAll<HTMLInputElement>(
-        'input[maxlength="1"][type="text"], input[maxlength="1"][type="tel"], input[maxlength="1"][type="number"], input[maxlength="1"]:not([type])'
+        'input[maxlength="1"][type="text"], input[maxlength="1"][type="tel"], input[maxlength="1"][type="number"], input[maxlength="1"]:not([type]), input[maxlength="2"][type="text"], input[maxlength="2"][type="tel"], input[maxlength="2"]:not([type])'
     );
 
-    // Find groups of 6 adjacent inputs
+    // Collect visible, interactive single-char inputs
+    const candidates: HTMLInputElement[] = [];
+    allInputs.forEach((input) => {
+        if (!input.offsetParent) return; // Skip hidden inputs
+        if (input.readOnly || input.disabled) return;
+        // For maxlength="2" inputs, also check if they're narrow (< 50px)
+        // which suggests they're single-digit OTP boxes
+        if (input.maxLength === 2) {
+            const rect = input.getBoundingClientRect();
+            if (rect.width > 50) return;
+        }
+        candidates.push(input);
+    });
+
+    // Find groups of 4-8 adjacent inputs using both DOM and visual proximity
     const groups: HTMLInputElement[][] = [];
     let currentGroup: HTMLInputElement[] = [];
 
-    allInputs.forEach((input) => {
-        if (!input.offsetParent) return; // Skip hidden inputs
-        // Skip readonly/disabled — MFA boxes are always interactive
-        if (input.readOnly || input.disabled) return;
+    for (let i = 0; i < candidates.length; i++) {
+        const input = candidates[i]!;
 
         if (currentGroup.length === 0) {
             currentGroup.push(input);
-        } else {
-            const lastInput = currentGroup[currentGroup.length - 1]!;
-            // Check if inputs are siblings or close in DOM
-            const isSibling =
-                lastInput.nextElementSibling === input ||
-                lastInput.parentElement === input.parentElement;
-            const isClose =
-                lastInput.parentElement?.parentElement ===
-                input.parentElement?.parentElement;
-
-            if (isSibling || isClose) {
-                currentGroup.push(input);
-            } else {
-                if (currentGroup.length >= 6) {
-                    groups.push(currentGroup);
-                }
-                currentGroup = [input];
-            }
+            continue;
         }
-    });
 
-    if (currentGroup.length >= 6) {
+        const lastInput = currentGroup[currentGroup.length - 1]!;
+
+        // Check structural proximity (DOM-based)
+        const isSibling =
+            lastInput.nextElementSibling === input ||
+            lastInput.parentElement === input.parentElement;
+        const hasCommonAncestor = findCommonAncestor(lastInput, input, 6) !== null;
+
+        // Check visual proximity (position-based)
+        const isVisuallyClose = areVisuallyAdjacent(lastInput, input);
+
+        if (isSibling || (hasCommonAncestor && isVisuallyClose) || isVisuallyClose) {
+            currentGroup.push(input);
+        } else {
+            if (currentGroup.length >= 4 && currentGroup.length <= 8) {
+                groups.push(currentGroup);
+            }
+            currentGroup = [input];
+        }
+    }
+
+    if (currentGroup.length >= 4 && currentGroup.length <= 8) {
         groups.push(currentGroup);
     }
 
-    // Return the first group of 6 inputs that isn't excluded (SMS / email / promo).
-    // Spot-check the first input — if it carries OOB signals, none of the
-    // siblings in the group are meant for TOTP either.
+    // Prefer groups of exactly 6 (most common OTP length), then 4, then others
+    groups.sort((a, b) => {
+        const preferredA = a.length === 6 ? 0 : a.length === 4 ? 1 : 2;
+        const preferredB = b.length === 6 ? 0 : b.length === 4 ? 1 : 2;
+        return preferredA - preferredB;
+    });
+
+    // Return the first valid group that isn't excluded (SMS / email / promo).
     for (const group of groups) {
-        if (group.length === 6 && !isExcludedField(group[0]!)) {
+        if (!isExcludedField(group[0]!)) {
             return {
                 element: group[0]!,
                 confidence: 0.85,

--- a/src/content/detector.ts
+++ b/src/content/detector.ts
@@ -110,6 +110,17 @@ const EXCLUSION_PATTERNS = [
     "via-text",
     "via-email",
     "sms-marketing",
+    // Search inputs — never MFA
+    "search",
+    "query",
+    "keyword",
+    "q",
+    "filter",
+    "find",
+    "lookup",
+    "autocomplete",
+    "typeahead",
+    "suggest",
     // Developer/API credentials that look superficially like MFA inputs
     // (e.g. GitHub Personal Access Token displayed in a text field).
     "personal-access-token",
@@ -422,6 +433,26 @@ const isExcludedField = (input: HTMLInputElement): boolean => {
  */
 const calculateConfidence = (input: HTMLInputElement): number => {
     if (isExcludedField(input)) return 0;
+
+    // Exclude search inputs — type="search", role="search", or inside a
+    // search form/container. These are never MFA fields.
+    if (input.type === "search") return 0;
+    if (input.getAttribute("role") === "searchbox" || input.getAttribute("role") === "combobox") return 0;
+    if (input.closest('[role="search"]') || input.closest('form[role="search"]')) return 0;
+
+    // Exclude inputs with no maxlength or very large maxlength (> 20).
+    // OTP fields never accept more than ~8 characters. This filters out
+    // general text inputs (search bars, address fields, etc.) that might
+    // accidentally score points via nearby text patterns.
+    // Only skip if there's no strong explicit signal (autocomplete="one-time-code")
+    if (input.autocomplete !== "one-time-code" &&
+        (input.maxLength === -1 || input.maxLength > 20)) {
+        // Still allow if name/id/class strongly suggests OTP
+        const nameIdClass = `${input.name || ""} ${input.id || ""} ${input.className || ""}`;
+        if (!matchesPattern(nameIdClass, MFA_ATTRIBUTE_PATTERNS)) {
+            return 0;
+        }
+    }
 
     let confidence = 0;
 

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -97,6 +97,7 @@ const renderIconForCurrentDetection = async (): Promise<void> => {
         }>({
             type: "GET_CODES_FOR_DOMAIN",
             domain,
+            path: window.location.pathname,
         });
 
         const matches = response?.data?.matches || [];

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -1028,7 +1028,9 @@ export const showPopup = (
 
     if (!inputElement) return;
 
-    // Get current domain
+    // Get current domain for display in the "Save mapping?" dialog.
+    // Path-based mappings (e.g., "auth.company.com/realms/prod") should be
+    // configured manually in Options for precision; auto-save uses hostname only.
     const domain = window.location.hostname;
 
     // Create shadow host

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -100,6 +100,13 @@ export const App: React.FC = () => {
         setSyncSuccess(false);
         try {
             await sendMessage({ type: "SYNC_CODES" });
+            // Refresh codes list so custom mapping dropdown has latest issuers
+            const codesResponse = await sendMessage<{ success: boolean; data?: { codes: Code[] } }>({
+                type: "GET_CODES",
+            });
+            if (codesResponse.success && codesResponse.data?.codes) {
+                setCodes(codesResponse.data.codes);
+            }
             setSyncSuccess(true);
             setTimeout(() => setSyncSuccess(false), 2000);
         } catch (e) {

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -389,7 +389,7 @@ export const App: React.FC = () => {
                                 <div className="form-row">
                                     <input
                                         type="text"
-                                        placeholder="Domain (e.g., mycompany.okta.com)"
+                                        placeholder="Domain (e.g., mycompany.okta.com or auth.co.com/realms/prod)"
                                         value={newMappingDomain}
                                         onChange={(e) => setNewMappingDomain(e.target.value)}
                                         className="form-input"

--- a/src/shared/domain-matcher.ts
+++ b/src/shared/domain-matcher.ts
@@ -101,27 +101,80 @@ const domainMatches = (hostname: string, domain: string): boolean => {
 };
 
 /**
+ * Parse a custom mapping domain string into hostname and optional path prefix.
+ * e.g., "auth.company.com/realms/prod" → { hostname: "auth.company.com", path: "/realms/prod" }
+ * e.g., "company.com" → { hostname: "company.com", path: "/" }
+ */
+const parseMappingDomain = (mappingDomain: string): { hostname: string; path: string } => {
+    const slashIndex = mappingDomain.indexOf("/");
+    if (slashIndex === -1) {
+        return { hostname: mappingDomain, path: "/" };
+    }
+    return {
+        hostname: mappingDomain.slice(0, slashIndex),
+        path: mappingDomain.slice(slashIndex),
+    };
+};
+
+/**
+ * Find the best matching custom mapping for a given hostname and path.
+ * When multiple mappings match, the one with the longest (most specific) path wins.
+ */
+const findBestCustomMapping = (hostname: string, currentPath: string): CustomDomainMapping | undefined => {
+    let bestMapping: CustomDomainMapping | undefined;
+    let bestPathLength = -1;
+
+    for (const mapping of customMappings) {
+        const { hostname: mappingHost, path: mappingPath } = parseMappingDomain(mapping.domain.toLowerCase());
+
+        // Check if hostname matches
+        if (!domainMatches(hostname, mappingHost) && hostname !== mappingHost) {
+            continue;
+        }
+
+        // Check if path matches (prefix match)
+        if (mappingPath !== "/" && !currentPath.startsWith(mappingPath)) {
+            continue;
+        }
+
+        // Prefer the most specific (longest) path match
+        if (mappingPath.length > bestPathLength) {
+            bestPathLength = mappingPath.length;
+            bestMapping = mapping;
+        }
+    }
+
+    return bestMapping;
+};
+
+/**
  * Match codes to a domain.
  *
  * @param codes The list of codes to search.
  * @param domain The domain to match against.
+ * @param path Optional URL path for path-prefix based custom mapping matching.
  * @returns Sorted list of matches with confidence scores.
  */
 export const matchCodesToDomain = (
     codes: Code[],
-    domain: string
+    domain: string,
+    path?: string
 ): DomainMatch[] => {
     const hostname = domain.toLowerCase();
     const baseDomain = getBaseDomain(hostname);
+    const currentPath = (path || "/").toLowerCase();
     const matches: DomainMatch[] = [];
 
     // Check if there's a custom mapping for this domain — if so, only return
     // codes that match the custom mapping. This prevents unrelated codes from
     // showing up alongside the explicitly configured one.
-    const activeCustomMapping = customMappings.find((mapping) => {
-        const mappingDomain = mapping.domain.toLowerCase();
-        return domainMatches(hostname, mappingDomain) || hostname === mappingDomain;
-    });
+    //
+    // Custom mappings support optional path prefixes. When a mapping domain
+    // contains a "/" (e.g., "auth.company.com/realms/prod"), the path is
+    // extracted and matched as a prefix against the current URL path.
+    // When multiple mappings match, the one with the longest (most specific)
+    // path wins.
+    const activeCustomMapping = findBestCustomMapping(hostname, currentPath);
 
     for (const code of codes) {
         const issuer = code.issuer.toLowerCase();
@@ -231,9 +284,10 @@ export const matchCodesToDomain = (
  */
 export const getBestMatch = (
     codes: Code[],
-    domain: string
+    domain: string,
+    path?: string
 ): DomainMatch | undefined => {
-    const matches = matchCodesToDomain(codes, domain);
+    const matches = matchCodesToDomain(codes, domain, path);
     return matches[0];
 };
 

--- a/src/shared/domain-matcher.ts
+++ b/src/shared/domain-matcher.ts
@@ -115,25 +115,25 @@ export const matchCodesToDomain = (
     const baseDomain = getBaseDomain(hostname);
     const matches: DomainMatch[] = [];
 
+    // Check if there's a custom mapping for this domain — if so, only return
+    // codes that match the custom mapping. This prevents unrelated codes from
+    // showing up alongside the explicitly configured one.
+    const activeCustomMapping = customMappings.find((mapping) => {
+        const mappingDomain = mapping.domain.toLowerCase();
+        return domainMatches(hostname, mappingDomain) || hostname === mappingDomain;
+    });
+
     for (const code of codes) {
         const issuer = code.issuer.toLowerCase();
         const normalizedIssuer = normalizeIssuer(code.issuer);
         let confidence = 0;
 
         // 0. Check custom mappings FIRST (confidence: 0.99, just below exact match)
-        // Custom mappings match on exact domain or subdomain
-        const customMatch = customMappings.find((mapping) => {
-            const mappingDomain = mapping.domain.toLowerCase();
-            // Match if the hostname matches the mapping domain exactly or as subdomain
-            return domainMatches(hostname, mappingDomain) || hostname === mappingDomain;
-        });
-
-        if (customMatch) {
-            // Check if this code's issuer matches the custom mapping
-            const mappingIssuerNormalized = normalizeIssuer(customMatch.issuer);
+        if (activeCustomMapping) {
+            const mappingIssuerNormalized = normalizeIssuer(activeCustomMapping.issuer);
             if (
                 normalizedIssuer === mappingIssuerNormalized ||
-                code.issuer.toLowerCase() === customMatch.issuer.toLowerCase() ||
+                code.issuer.toLowerCase() === activeCustomMapping.issuer.toLowerCase() ||
                 // Also match if code issuer contains the mapping issuer or vice versa
                 // This handles cases like code issuer "FinPoints GitLab" matching mapping issuer "GitLab"
                 // Only apply substring matching when the shorter string is at least 4 chars
@@ -141,6 +141,9 @@ export const matchCodesToDomain = (
                 (normalizedIssuer.length >= 4 && mappingIssuerNormalized.includes(normalizedIssuer))
             ) {
                 confidence = 0.99;
+            } else {
+                // Custom mapping exists but this code doesn't match it — skip
+                continue;
             }
         }
 

--- a/src/shared/domain-matcher.ts
+++ b/src/shared/domain-matcher.ts
@@ -133,7 +133,12 @@ export const matchCodesToDomain = (
             const mappingIssuerNormalized = normalizeIssuer(customMatch.issuer);
             if (
                 normalizedIssuer === mappingIssuerNormalized ||
-                code.issuer.toLowerCase() === customMatch.issuer.toLowerCase()
+                code.issuer.toLowerCase() === customMatch.issuer.toLowerCase() ||
+                // Also match if code issuer contains the mapping issuer or vice versa
+                // This handles cases like code issuer "FinPoints GitLab" matching mapping issuer "GitLab"
+                // Only apply substring matching when the shorter string is at least 4 chars
+                (mappingIssuerNormalized.length >= 4 && normalizedIssuer.includes(mappingIssuerNormalized)) ||
+                (normalizedIssuer.length >= 4 && mappingIssuerNormalized.includes(normalizedIssuer))
             ) {
                 confidence = 0.99;
             }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -135,7 +135,7 @@ export interface ParsedQRCode {
  */
 export type ExtensionMessage =
     | { type: "GET_CODES"; forceSync?: boolean }
-    | { type: "GET_CODES_FOR_DOMAIN"; domain: string }
+    | { type: "GET_CODES_FOR_DOMAIN"; domain: string; path?: string }
     | { type: "SYNC_CODES" }
     | { type: "LOGIN"; token: string; keyAttributes: KeyAttributes }
     | { type: "LOGIN_COMPLETE"; token: string; email: string; keyAttributes: KeyAttributes; masterKey: string }
@@ -221,7 +221,7 @@ export interface DomainMatch {
  * Custom domain mapping created by the user.
  */
 export interface CustomDomainMapping {
-    /** The domain to match, e.g., "mycompany.okta.com" */
+    /** The domain to match, e.g., "mycompany.okta.com" or "auth.company.com/realms/prod" */
     domain: string;
     /** The issuer name to match, e.g., "Okta - Work" (matches Code.issuer) */
     issuer: string;


### PR DESCRIPTION
Fixes multiple issues with MFA field detection, custom domain mapping behavior, and adds cross-device sync for custom mappings.

## Changes

### 1. Improve split OTP detection for deeply nested DOM structures

The previous detection only checked direct siblings and grandparent relationships, failing on modern frameworks (React/Vue) where each input is wrapped in multiple layers of divs.

- Add visual proximity detection using getBoundingClientRect()
- Expand common ancestor search to 6 levels (was 2)
- Accept groups of 4-8 inputs (not just exactly 6)
- Handle maxlength="2" narrow inputs used by some OTP implementations
- Prioritize groups of 6 (standard TOTP length) over others

### 2. Fix custom domain mappings not effective after sync

- Options page: refresh the codes list after clicking "Sync now" so the issuer dropdown stays up-to-date
- Domain matcher: support substring matching (min 4 chars) for custom mapping issuer comparison

### 3. Only show custom-mapped code when a custom mapping exists

When a custom mapping is configured for a domain, other codes that happen to fuzzy-match are no longer shown. Only the explicitly mapped code appears in the autofill dropdown.

### 4. Sync custom domain mappings across devices

Custom mappings now use browser.storage.sync instead of local storage, enabling automatic sync across devices logged into the same browser account. Includes one-time migration from local storage.

### 5. Exclude search inputs from MFA detection

Search boxes were falsely detected as OTP fields when nearby page text contained MFA-related keywords.

- Add search-related terms to exclusion patterns
- Early-exit for type="search", role="searchbox"/"combobox", and inputs inside role="search" containers
- Skip inputs with no maxlength or maxlength > 20 unless they have explicit OTP signals
